### PR TITLE
Update log4j to 2.17 to address CVE-2021-45105.

### DIFF
--- a/log4j-1.2.17/src/META-INF/maven/log4j/log4j/pom.xml
+++ b/log4j-1.2.17/src/META-INF/maven/log4j/log4j/pom.xml
@@ -33,8 +33,8 @@ target platform and specify -Dntdll_target=msbuild on the mvn command line.
   <packaging>bundle</packaging>
   <name>Apache Log4j</name>
   <version>1.2.17</version>
-  <description>Apache Log4j 1.2</description>
-  <url>http://logging.apache.org/log4j/1.2/</url>
+  <description>Apache Log4j 2.17.0</description>
+  <url>http://logging.apache.org/log4j/2.17.0/</url>
   <issueManagement>
     <system>Bugzilla</system>
     <url>https://issues.apache.org/bugzilla/describecomponents.cgi?product=Log4j</url>


### PR DESCRIPTION
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45105